### PR TITLE
Fixed cu1 gate, added matrices size function and removed errors in apply gates functions

### DIFF
--- a/src/simulators/tensor_network/matrix_product_state.cpp
+++ b/src/simulators/tensor_network/matrix_product_state.cpp
@@ -104,9 +104,10 @@ void MPS::apply_cz(uint_t index_A, uint_t index_B)
 {
   apply_2_qubit_gate(index_A, index_B, cz, cmatrix_t(1));
 }
-void MPS::apply_cu(uint_t index_A, uint_t index_B, cmatrix_t mat)
+void MPS::apply_cu1(uint_t index_A, uint_t index_B, double lambda)
 {
-  apply_2_qubit_gate(index_A, index_B, cu, mat);
+  cmatrix_t u1_matrix = AER::Utils::Matrix::u1(lambda);
+  apply_2_qubit_gate(index_A, index_B, cu1, u1_matrix);
 }
 void MPS::apply_su4(uint_t index_A, uint_t index_B, cmatrix_t mat)
 {
@@ -210,7 +211,7 @@ void MPS::apply_2_qubit_gate(uint_t index_A, uint_t index_B, Gates gate_type, cm
 	case cz:
 	  temp.apply_cz();
 	  break;
-	case cu:
+	case cu1:
 	{
 	  cmatrix_t Zeros = AER::Utils::Matrix::I-AER::Utils::Matrix::I;
 	  cmatrix_t temp1 = AER::Utils::concatenate(AER::Utils::Matrix::I, Zeros , 1),
@@ -335,6 +336,16 @@ ostream& MPS::print(ostream& out) const
 	}
 	out << endl;
 	return out;
+}
+
+vector<reg_t> MPS::get_marices_size() const
+{
+	vector<reg_t> result;
+	for(uint_t i=0; i<num_qubits_; i++)
+	{
+		result.push_back(q_reg_[i].get_size());
+	}
+	return result;
 }
 
 MPS_Tensor MPS::state_vec(uint_t first_index, uint_t last_index) const

--- a/src/simulators/tensor_network/matrix_product_state.hpp
+++ b/src/simulators/tensor_network/matrix_product_state.hpp
@@ -19,7 +19,7 @@ namespace TensorNetworkState {
 // Allowed gates enum class
 enum Gates {
   id, h, x, y, z, s, sdg, t, tdg, u1, u2, u3, // single qubit
-  cx, cz, cu, swap, su4 // two qubit
+  cx, cz, cu1, swap, su4 // two qubit
 };
 
 //=========================================================================
@@ -96,7 +96,7 @@ public:
   void apply_cnot(uint_t index_A, uint_t index_B);
   void apply_swap(uint_t index_A, uint_t index_B);
   void apply_cz(uint_t index_A, uint_t index_B);
-  void apply_cu(uint_t index_A, uint_t index_B, cmatrix_t mat);
+  void apply_cu1(uint_t index_A, uint_t index_B, double lambda);
   void apply_su4(uint_t index_A, uint_t index_B, cmatrix_t mat);
   void apply_2_qubit_gate(uint_t index_A, uint_t index_B, Gates gate_type, cmatrix_t mat);
   
@@ -132,6 +132,12 @@ public:
   // Description: prints the MPS
   //----------------------------------------------------------------	
    virtual ostream&  print(ostream& out) const;
+
+   //----------------------------------------------------------------
+   // function name: get_marices_size
+   // Description: returns the size of the inner matrices of the MPS
+   //----------------------------------------------------------------
+   vector<reg_t> get_marices_size() const;
 
   //----------------------------------------------------------------
   // function name: state_vec

--- a/src/simulators/tensor_network/matrix_product_state_tensor.hpp
+++ b/src/simulators/tensor_network/matrix_product_state_tensor.hpp
@@ -94,6 +94,7 @@ public:
     return *this;
   }
   virtual ostream& print(ostream& out) const;
+  reg_t get_size() const;
   cvector_t get_data(uint_t a1, uint_t a2) const;
   cmatrix_t get_data(uint_t i) const {
     return data_[i];
@@ -156,6 +157,20 @@ ostream& MPS_Tensor::print(ostream& out) const{
 
     return out;
 }
+
+//**************************************************************
+// function name: get_size
+// Description: get size of the matrices of the tensor.
+// Parameters: none.
+// Returns: reg_t of size 2, for rows and columns.
+//**************************************************************
+reg_t MPS_Tensor::get_size() const
+{
+	reg_t result;
+	result.push_back(data_[0].GetRows());
+	result.push_back(data_[0].GetColumns());
+	return result;
+}
   
 //----------------------------------------------------------------
 // function name: get_data
@@ -195,20 +210,10 @@ void MPS_Tensor::insert_data(uint_t a1, uint_t a2, cvector_t data)
 //---------------------------------------------------------------
 void MPS_Tensor::apply_x()
 {
-  if (data_.size() != 2)
-    {
-      cout << "ERROR: The tensor doesn't represent one qubit" << '\n';
-      assert(false);
-    }
   swap(data_[0],data_[1]);
 }
   void MPS_Tensor::apply_y()
   {
-    if (data_.size() != 2)
-      {
-	cout << "ERROR: The tensor doesn't represent one qubit" << '\n';
-	assert(false);
-      }
     data_[0] = data_[0] * complex_t(0, 1);
     data_[1] = data_[1] * complex_t(0, -1);
     swap(data_[0],data_[1]);
@@ -216,79 +221,43 @@ void MPS_Tensor::apply_x()
 
 void MPS_Tensor::apply_z()
 {
-  if (data_.size() != 2)
-    {
-      cout << "ERROR: The tensor doesn't represent one qubit" << '\n';
-      assert(false);
-    }
   data_[1] = data_[1] * (-1.0);
 }
 
 void MPS_Tensor::apply_s()
 {
-  if (data_.size() != 2)
-    {
-      cout << "ERROR: The tensor doesn't represent one qubit" << '\n';
-      assert(false);
-    }
   data_[1] = data_[1] * complex_t(0, 1);
 }
 
 void MPS_Tensor::apply_sdg()
 {
-  if (data_.size() != 2)
-    {
-      cout << "ERROR: The tensor doesn't represent one qubit" << '\n';
-      assert(false);
-    }
   data_[1] = data_[1] * complex_t(0, -1);
 }
   
 void MPS_Tensor::apply_t()
 {
-  if (data_.size() != 2)
-    {
-      cout << "ERROR: The tensor doesn't represent one qubit" << '\n';
-      assert(false);
-    }
   data_[1] = data_[1] * complex_t(SQR_HALF, SQR_HALF);
 }
 
 void MPS_Tensor::apply_tdg()
 {
-  if (data_.size() != 2)
-    {
-      cout << "ERROR: The tensor doesn't represent one qubit" << '\n';
-      assert(false);
-    }
   data_[1] = data_[1] * complex_t(SQR_HALF, -SQR_HALF);
 }
 
 void MPS_Tensor::apply_matrix(cmatrix_t &mat)
 {
-  if (data_.size() != mat.GetRows())
-    {
-      cout << "ERROR: The matrix and tensor doesn't represent the same number of qubits" << '\n';
-      assert(false);
-    }
-
   cvector_t temp;
   for (uint_t a1 = 0; a1 < data_[0].GetRows(); a1++)
     for (uint_t a2 = 0; a2 < data_[0].GetColumns(); a2++)
-      {
-	temp = get_data(a1,a2);
-	temp = mat * temp;
-	insert_data(a1,a2,temp);
-      }
+    {
+	  temp = get_data(a1,a2);
+	  temp = mat * temp;
+	  insert_data(a1,a2,temp);
+    }
 }
 
 void MPS_Tensor::apply_cnot(bool swapped)
 {
-  if (data_.size() != 4)
-    {
-      cout << "ERROR: The tensor doesn't represent 2 qubits" << '\n';
-      assert(false);
-    }
   if(!swapped)
     swap(data_[2],data_[3]);
   else
@@ -297,21 +266,11 @@ void MPS_Tensor::apply_cnot(bool swapped)
 
 void MPS_Tensor::apply_swap()
 {
-  if (data_.size() != 4)
-    {
-      cout << "ERROR: The tensor doesn't represent 2 qubits" << '\n';
-      assert(false);
-    }
   swap(data_[1],data_[2]);
 }
 
 void MPS_Tensor::apply_cz()
 {
-  if (data_.size() != 4)
-    {
-      cout << "ERROR: The tensor doesn't represent 2 qubits" << '\n';
-      assert(false);
-    }
   data_[3] = data_[3] * (-1.0);
 }
 

--- a/src/simulators/tensor_network/tensor_network_state.hpp
+++ b/src/simulators/tensor_network/tensor_network_state.hpp
@@ -294,8 +294,7 @@ const stringmap_t<Gates> State::gateset_({
   {"CX", Gates::cx},     // Controlled-X gate (CNOT)
   {"cx", Gates::cx},     // Controlled-X gate (CNOT)
   {"cz", Gates::cz},     // Controlled-Z gate
-  {"cu", Gates::cu},     // Controlled-U gate
-  {"cu1", Gates::cu},     // Controlled-U gate
+  {"cu1", Gates::cu1},     // Controlled-U1 gate
   {"swap", Gates::swap}, // SWAP gate
   {"su4", Gates::su4},   // general su4 matrix gate
   // Three-qubit gates
@@ -561,6 +560,10 @@ void State::apply_gate(const Operations::Op &op) {
       break;
     case Gates::cz:
       qreg_.apply_cz(op.qubits[0], op.qubits[1]);
+      break;
+    case Gates::cu1:
+      qreg_.apply_cu1(op.qubits[0], op.qubits[1],
+    		  	  	  	  std::real(op.params[0]));
       break;
     default:
       // We shouldn't reach here unless there is a bug in gateset


### PR DESCRIPTION
1. cu1 changed from cu. currently get only one parameter (and not a matrix)
2. Support of get the size of the internal matrices of each tensor and of the full MPS
3. I removed the checking of number of qubits before applying the gates.