### PR TITLE
Fix set_mps op

### DIFF
--- a/qiskit/providers/aer/library/set_instructions/set_matrix_product_state.py
+++ b/qiskit/providers/aer/library/set_instructions/set_matrix_product_state.py
@@ -46,7 +46,7 @@ class SetMatrixProductState(Instruction):
         print("num qubits is " + str(len(mps_state[0])))
         print(mps_state)
         print("aaa")
-        super().__init__('set_matrix_product_state', len(mps_state[0]), 0, mps_state)
+        super().__init__('set_matrix_product_state', len(mps_state[0]), 0, [mps_state])
 
 
 def set_matrix_product_state(self, mps_state):

--- a/src/framework/operations.hpp
+++ b/src/framework/operations.hpp
@@ -1051,8 +1051,8 @@ Op input_to_op_set_mps(const inputdata_t &input, OpType op_type) {
 
   Op op;
   op.type = op_type;
-  const inputdata_t& temp = Parser<inputdata_t>::get_value("params", input);
-  op.mps = temp;
+  const inputdata_t& params = Parser<inputdata_t>::get_value("params", input);
+  op.mps = Parser<inputdata_t>::template get_list_elem<mps_container_t>(params, 0);
 
   Parser<inputdata_t>::get_value(op.name, "name", input);
   Parser<inputdata_t>::get_value(op.qubits, "qubits", input);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I've made two small changes to make it work:

- In `set_matrix_product_state.py` I pass `mps_state` within a `list`, as `parameters` is assumed to be a `list`.
- In `input_to_op_set_mps` I get `params` first and then get the first element of `params` as a `mps_container_t`.

 In the test code I also had to slightly change the `mps_data` structure a little to make it match with the C++ structure. Last item of the `tuple` has to be a `list` of `list`s:
 
new_mps = ( [ ( [[0]], [[1]] ), ( [[1]], [[0]]  ) ],  **[**   [1.]   **]**  )

As the structure is kind of complex I think we need to add a validation: check that it is a tuple with 2 elements, the first element is a list of tuples, etc. It can be done on the C++ side, but I think it is better to do in the python side (maybe even in both sides).

### Details and comments


