### PR TITLE
[WIP] MPS::apply_measure - small performance optimization

### DIFF
--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class AerSimulator(AerBackend):
-    r"""
+    """
     Noisy quantum circuit simulator backend.
 
     **Configurable Options**
@@ -299,13 +299,13 @@ class AerSimulator(AerBackend):
       ``"mps_probabilities"``first constructs the probability vector and
       then generates a sample per shot. It is more efficient for a large number
       of shots and a small number of
-      qubits, with complexity :math:`O(2^n n \chi^2)' to create the vector and
-      O(1) per shot, where n is the number of qubits and :math:`\chi'
+      qubits, with complexity O(2^n * n * D^2) to create the vector and
+      O(1) per shot, where n is the number of qubits and D
       is the bond dimension.
       ``"mps_apply_measure"`` creates a copy of the mps structure and
       measures directly on it. It is more efficient for a small number of
       shots, and a high number of qubits, with complexity around
-      :math:`O(n \chi^2)'
+      O(n * D^2)
       per shot.
       (Default: "mps_apply_measure").
 

--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -225,30 +225,30 @@ class AerSimulator(AerBackend):
     These backend options only apply when using the ``"extended_stabilizer"``
     simulation method:
 
-    * ``extended_stabilizer_sampling_methid`` (string): Choose how to simulate
+    * ``extended_stabilizer_sampling_method`` (string): Choose how to simulate
       measurements on qubits. The performance of the simulator depends
       significantly on this choice. In the following, let n be the number of
       qubits in the circuit, m the number of qubits measured, and S be the
       number of shots. (Default: resampled_metropolis)
 
-      * ``"metropolis"``: Use a Monte-Carlo method to sample many output
-        strings from the simulator at once. To be accurate, this method
-        requires that all the possible output strings have a non-zero
-        probability. It will give inaccurate results on cases where
-        the circuit has many zero-probability outcomes.
-        This method has an overall runtime that scales as n^{2} + (S-1)n.
+    * ``"metropolis"``: Use a Monte-Carlo method to sample many output
+      strings from the simulator at once. To be accurate, this method
+      requires that all the possible output strings have a non-zero
+      probability. It will give inaccurate results on cases where
+      the circuit has many zero-probability outcomes.
+      This method has an overall runtime that scales as n^{2} + (S-1)n.
 
-      * ``"resampled_metropolis"``: A variant of the metropolis method,
-        where the Monte-Carlo method is reinitialised for every shot. This
-        gives better results for circuits where some outcomes have zero
-        probability, but will still fail if the output distribution
-        is sparse. The overall runtime scales as Sn^{2}.
+    * ``"resampled_metropolis"``: A variant of the metropolis method,
+      where the Monte-Carlo method is reinitialised for every shot. This
+      gives better results for circuits where some outcomes have zero
+      probability, but will still fail if the output distribution
+      is sparse. The overall runtime scales as Sn^{2}.
 
-      * ``"norm_estimation"``: An alternative sampling method using
-        random state inner products to estimate outcome probabilites. This
-        method requires twice as much memory, and significantly longer
-        runtimes, but gives accurate results on circuits with sparse
-        output distributions. The overall runtime scales as Sn^{3}m^{3}.
+    * ``"norm_estimation"``: An alternative sampling method using
+      random state inner products to estimate outcome probabilites. This
+      method requires twice as much memory, and significantly longer
+      runtimes, but gives accurate results on circuits with sparse
+      output distributions. The overall runtime scales as Sn^{3}m^{3}.
 
     * ``extended_stabilizer_metropolis_mixing_time`` (int): Set how long the
       monte-carlo method runs before performing measurements. If the
@@ -308,6 +308,7 @@ class AerSimulator(AerBackend):
       O(n * D^2)
       per shot.
       (Default: "mps_apply_measure").
+
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -304,9 +304,8 @@ class AerSimulator(AerBackend):
       is the bond dimension.
       ``"mps_apply_measure"`` creates a copy of the mps structure and
       measures directly on it. It is more efficient for a small number of
-      shots, and a high number of qubits, with complexity around
-      O(n * D^2)
-      per shot.
+      shots, and a large number of qubits, with complexity around
+      O(n * D^2) per shot.
       (Default: "mps_apply_measure").
 
     * ``mps_log_data`` (str): if True, output logging data of the MPS

--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -308,7 +308,6 @@ class AerSimulator(AerBackend):
       O(n * D^2)
       per shot.
       (Default: "mps_apply_measure").
-
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/aer_simulator.py
+++ b/qiskit/providers/aer/backends/aer_simulator.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class AerSimulator(AerBackend):
-    """
+    r"""
     Noisy quantum circuit simulator backend.
 
     **Configurable Options**
@@ -295,14 +295,20 @@ class AerSimulator(AerBackend):
       (Default: 1e-16).
 
     * ``mps_sample_measure_algorithm`` (str):
-      Choose which algorithm to use for ``"sample_measure"``. ``"mps_probabilities"``
-      means all state probabilities are computed and measurements are based on them.
-      It is more efficient for a large number of shots, small number of qubits and low
-      entanglement. ``"mps_apply_measure"`` creates a copy of the mps structure and
-      makes a measurement on it. It is more effients for a small number of shots, high
-      number of qubits, and low entanglement. If the user does not specify the algorithm,
-      a heuristic algorithm is used to select between the two algorithms.
-      (Default: "mps_heuristic").
+      Choose which algorithm to use for ``"sample_measure"``.
+      ``"mps_probabilities"``first constructs the probability vector and
+      then generates a sample per shot. It is more efficient for a large number
+      of shots and a small number of
+      qubits, with complexity :math:`O(2^n n \chi^2)' to create the vector and
+      O(1) per shot, where n is the number of qubits and :math:`\chi'
+      is the bond dimension.
+      ``"mps_apply_measure"`` creates a copy of the mps structure and
+      measures directly on it. It is more efficient for a small number of
+      shots, and a high number of qubits, with complexity around
+      :math:`O(n \chi^2)'
+      per shot.
+      (Default: "mps_apply_measure").
+
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -266,7 +266,7 @@ class QasmSimulator(AerBackend):
       O(n * D^2)
       per shot.
       (Default: "mps_apply_measure").
-      
+
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -262,9 +262,8 @@ class QasmSimulator(AerBackend):
       is the bond dimension.
       ``"mps_apply_measure"`` creates a copy of the mps structure and
       measures directly on it. It is more efficient for a small number of
-      shots, and a high number of qubits, with complexity around
-      O(n * D^2)
-      per shot.
+      shots, and a large number of qubits, with complexity around
+      O(n * D^2) per shot.
       (Default: "mps_apply_measure").
 
     * ``mps_log_data`` (str): if True, output logging data of the MPS

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -266,7 +266,6 @@ class QasmSimulator(AerBackend):
       O(n * D^2)
       per shot.
       (Default: "mps_apply_measure").
-
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -189,24 +189,24 @@ class QasmSimulator(AerBackend):
       qubits in the circuit, m the number of qubits measured, and S be the
       number of shots. (Default: resampled_metropolis)
 
-      * ``"metropolis"``: Use a Monte-Carlo method to sample many output
-        strings from the simulator at once. To be accurate, this method
-        requires that all the possible output strings have a non-zero
-        probability. It will give inaccurate results on cases where
-        the circuit has many zero-probability outcomes.
-        This method has an overall runtime that scales as n^{2} + (S-1)n.
+    * ``"metropolis"``: Use a Monte-Carlo method to sample many output
+      strings from the simulator at once. To be accurate, this method
+      requires that all the possible output strings have a non-zero
+      probability. It will give inaccurate results on cases where
+      the circuit has many zero-probability outcomes.
+      This method has an overall runtime that scales as n^{2} + (S-1)n.
 
-      * ``"resampled_metropolis"``: A variant of the metropolis method,
-        where the Monte-Carlo method is reinitialised for every shot. This
-        gives better results for circuits where some outcomes have zero
-        probability, but will still fail if the output distribution
-        is sparse. The overall runtime scales as Sn^{2}.
+    * ``"resampled_metropolis"``: A variant of the metropolis method,
+      where the Monte-Carlo method is reinitialised for every shot. This
+      gives better results for circuits where some outcomes have zero
+      probability, but will still fail if the output distribution
+      is sparse. The overall runtime scales as Sn^{2}.
 
-      * ``"norm_estimation"``: An alternative sampling method using
-        random state inner products to estimate outcome probabilites. This
-        method requires twice as much memory, and significantly longer
-        runtimes, but gives accurate results on circuits with sparse
-        output distributions. The overall runtime scales as Sn^{3}m^{3}.
+    * ``"norm_estimation"``: An alternative sampling method using
+      random state inner products to estimate outcome probabilites. This
+      method requires twice as much memory, and significantly longer
+      runtimes, but gives accurate results on circuits with sparse
+      output distributions. The overall runtime scales as Sn^{3}m^{3}.
 
     * ``extended_stabilizer_metropolis_mixing_time`` (int): Set how long the
       monte-carlo method runs before performing measurements. If the
@@ -252,7 +252,7 @@ class QasmSimulator(AerBackend):
       their squares is smaller than this threshold.
       (Default: 1e-16).
 
-     * ``mps_sample_measure_algorithm`` (str):
+    * ``mps_sample_measure_algorithm`` (str):
       Choose which algorithm to use for ``"sample_measure"``.
       ``"mps_probabilities"``first constructs the probability vector and
       then generates a sample per shot. It is more efficient for a large number
@@ -266,6 +266,7 @@ class QasmSimulator(AerBackend):
       O(n * D^2)
       per shot.
       (Default: "mps_apply_measure").
+      
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class QasmSimulator(AerBackend):
-    """
+    r"""
     Noisy quantum circuit simulator backend.
 
     **Configurable Options**
@@ -266,7 +266,7 @@ class QasmSimulator(AerBackend):
       :math:`O(n \chi^2)'
       per shot.
       (Default: "mps_apply_measure").
-      
+
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -252,15 +252,21 @@ class QasmSimulator(AerBackend):
       their squares is smaller than this threshold.
       (Default: 1e-16).
 
-    * ``mps_sample_measure_algorithm`` (str):
-      Choose which algorithm to use for ``"sample_measure"``. ``"mps_probabilities"``
-      means all state probabilities are computed and measurements are based on them.
-      It is more efficient for a large number of shots, small number of qubits and low
-      entanglement. ``"mps_apply_measure"`` creates a copy of the mps structure and
-      makes a measurement on it. It is more effients for a small number of shots, high
-      number of qubits, and low entanglement. If the user does not specify the algorithm,
-      a heuristic algorithm is used to select between the two algorithms.
-      (Default: "mps_heuristic").
+     * ``mps_sample_measure_algorithm`` (str):
+      Choose which algorithm to use for ``"sample_measure"``.
+      ``"mps_probabilities"``first constructs the probability vector and
+      then generates a sample per shot. It is more efficient for a large number
+      of shots and a small number of
+      qubits, with complexity :math:`O(2^n n \chi^2)' to create the vector and
+      O(1) per shot, where n is the number of qubits and :math:`\chi'
+      is the bond dimension.
+      ``"mps_apply_measure"`` creates a copy of the mps structure and
+      measures directly on it. It is more efficient for a small number of
+      shots, and a high number of qubits, with complexity around
+      :math:`O(n \chi^2)'
+      per shot.
+      (Default: "mps_apply_measure").
+      
     * ``mps_log_data`` (str): if True, output logging data of the MPS
       structure: bond dimensions and values discarded during approximation.
       (Default: False)

--- a/qiskit/providers/aer/backends/qasm_simulator.py
+++ b/qiskit/providers/aer/backends/qasm_simulator.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class QasmSimulator(AerBackend):
-    r"""
+    """
     Noisy quantum circuit simulator backend.
 
     **Configurable Options**
@@ -257,13 +257,13 @@ class QasmSimulator(AerBackend):
       ``"mps_probabilities"``first constructs the probability vector and
       then generates a sample per shot. It is more efficient for a large number
       of shots and a small number of
-      qubits, with complexity :math:`O(2^n n \chi^2)' to create the vector and
-      O(1) per shot, where n is the number of qubits and :math:`\chi'
+      qubits, with complexity O(2^n * n * D^2) to create the vector and
+      O(1) per shot, where n is the number of qubits and D
       is the bond dimension.
       ``"mps_apply_measure"`` creates a copy of the mps structure and
       measures directly on it. It is more efficient for a small number of
       shots, and a high number of qubits, with complexity around
-      :math:`O(n \chi^2)'
+      O(n * D^2)
       per shot.
       (Default: "mps_apply_measure").
 

--- a/qiskit/providers/aer/noise/errors/standard_errors.py
+++ b/qiskit/providers/aer/noise/errors/standard_errors.py
@@ -17,10 +17,10 @@ import itertools as it
 
 import numpy as np
 
-from qiskit.quantum_info.operators.pauli import Pauli
 from qiskit.quantum_info.operators.channel import Choi, Kraus
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 from qiskit.quantum_info.operators.predicates import is_identity_matrix
+from qiskit.quantum_info.operators.symplectic.pauli import Pauli
 
 from ..noiseerror import NoiseError
 from .errorutils import make_unitary_instruction

--- a/releasenotes/notes/config.yaml
+++ b/releasenotes/notes/config.yaml
@@ -1,0 +1,3 @@
+---
+encoding: utf8
+default_branch: main

--- a/releasenotes/notes/mps_performance-apply_measure-e81837c4acd0e0f0.yaml
+++ b/releasenotes/notes/mps_performance-apply_measure-e81837c4acd0e0f0.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    Performance improvement in algorithm for apply_measure in MPS: this 
+    generalizes the improvement done for all qubits to any subset of the qubits.
+    Also removed the heuristic for choosing the algorithm for sample_measure.
+    The default is now `mps_apply_measure` and the user can specify 
+    'mps_probabilities` if she prefers that algorithm.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,5 +11,5 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-automodapi
 jupyter-sphinx;python_version<'3.8'
-reno>=3.1.0
+reno>=3.4.0
 ddt>=1.2.0,!=1.4.0

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -165,7 +165,7 @@ public:
   std::vector<reg_t> 
   sample_measure_using_apply_measure(const reg_t &qubits,
 				     uint_t shots,
-				     RngEngine &rng) const;
+				     RngEngine &rng);
 
   //-----------------------------------------------------------------------
   // Additional methods
@@ -1035,7 +1035,7 @@ std::vector<reg_t> State::
 sample_measure_using_probabilities(const reg_t &qubits,
 				   uint_t shots,
 				   RngEngine &rng) {
-
+  std::cout << "in sample_measure_using_probabilities" << std::endl;
   // Generate flat register for storing
   rvector_t rnds;
   rnds.reserve(shots);
@@ -1062,10 +1062,15 @@ sample_measure_using_probabilities(const reg_t &qubits,
 std::vector<reg_t> State::
   sample_measure_using_apply_measure(const reg_t &qubits, 
 				     uint_t shots, 
-				     RngEngine &rng) const {
+				     RngEngine &rng) {
 
   std::vector<reg_t> all_samples;
   all_samples.resize(shots);
+  // since input is always sorted in qasm_controller, therefore, we must return the qubits 
+  // to their original location (sorted)
+  qreg_.move_all_qubits_to_sorted_ordering();
+  reg_t sorted_qubits = qubits;
+  std::sort(sorted_qubits.begin(), sorted_qubits.end());
 
   #pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
   {
@@ -1073,7 +1078,7 @@ std::vector<reg_t> State::
     #pragma omp for
     for (int_t i=0; i<static_cast<int_t>(shots);  i++) {
       temp.initialize(qreg_);
-      auto single_result = temp.apply_measure(qubits, rng);
+      auto single_result = temp.apply_measure(sorted_qubits, rng);
       all_samples[i] = single_result;
     }
   }

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -1067,10 +1067,10 @@ std::vector<reg_t> State::
   std::vector<reg_t> all_samples;
   all_samples.resize(shots);
 
-  //#pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
+  #pragma omp parallel if (BaseState::threads_ > 1) num_threads(BaseState::threads_)
   {
     MPS temp;
-    //#pragma omp for
+    #pragma omp for
     for (int_t i=0; i<static_cast<int_t>(shots);  i++) {
       temp.initialize(qreg_);
       auto single_result = temp.apply_measure(qubits, rng);

--- a/src/simulators/matrix_product_state/matrix_product_state.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state.hpp
@@ -1078,7 +1078,7 @@ std::vector<reg_t> State::
     #pragma omp for
     for (int_t i=0; i<static_cast<int_t>(shots);  i++) {
       temp.initialize(qreg_);
-      auto single_result = temp.apply_measure(sorted_qubits, rng);
+      auto single_result = temp.apply_measure(sorted_qubits, rng, true);
       all_samples[i] = single_result;
     }
   }

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -1498,6 +1498,7 @@ reg_t MPS::apply_measure_internal(const reg_t &qubits,
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
 
   bool measure_right_neighbor = false;
+  // here we check if the next qubit to be measured is r (r's index is i+1)
   for (uint_t i=0; i<size; i++) {
     measure_right_neighbor = (i<size-1 && sorted_qubits[i+1] == i+1);
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -1484,14 +1484,14 @@ reg_t MPS::apply_measure_internal(const reg_t &qubits,
   // When all qubits are measured, then for every qubit measured, it is sufficient to 
   // propagate to the nearest neighbors because the neighbors will be measured next
   reg_t qubits_to_update;
-  reg_t outcome_vector(qubits.size());
+  uint_t size = qubits.size();
+  reg_t outcome_vector(size);
   reg_t sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
 
   bool measure_right_neighbor = false;
-  for (uint_t i=0; i<qubits.size(); i++) {
-    measure_right_neighbor = (i<sorted_qubits.size()-1 && 
-			      sorted_qubits[i+1] == i+1);
+  for (uint_t i=0; i<size; i++) {
+    measure_right_neighbor = (i<size-1 && sorted_qubits[i+1] == i+1);
 
     // The following line is correct because the qubits were sorted in apply_measure.
     // If the sort is cancelled, for the case of measure_all, we must measure

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -1443,7 +1443,6 @@ reg_t MPS::sample_measure_using_probabilities(const rvector_t &rnds,
 					      const reg_t &qubits) {
   // since input is always sorted in qasm_controller, we must return the qubits 
   // to their original location (sorted)
-  std::cout << "in sample_measure" << std::endl;
   move_all_qubits_to_sorted_ordering();
   return sample_measure_using_probabilities_internal(rnds, qubits);
 }
@@ -1489,8 +1488,8 @@ reg_t MPS::apply_measure_internal(const reg_t &qubits,
   reg_t sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
 
+  bool measure_right_neighbor = false;
   for (uint_t i=0; i<qubits.size(); i++) {
-    bool measure_right_neighbor = false;
     measure_right_neighbor = (i<sorted_qubits.size()-1 && 
 			      sorted_qubits[i+1] == i+1);
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -1481,8 +1481,16 @@ reg_t MPS::apply_measure(const reg_t &qubits, RngEngine &rng) {
 
 reg_t MPS::apply_measure_internal(const reg_t &qubits, 
 				  RngEngine &rng) {
-  // When all qubits are measured, then for every qubit measured, it is sufficient to 
-  // propagate to the nearest neighbors because the neighbors will be measured next
+  // For every qubit, q,  that is measured, we must propagate the effect of its
+  // measurement to its neigbors, l and r, and then to their neighbors, and 
+  // so on. If r (or l) is measured next, then there is no need to propagate to
+  // its next neighbor because we can propagate the effects of measuring q 
+  // and r together.
+  // We sort 'qubits' at the beginning of the algorithm, so that the index of 
+  // the next measured qubit will always be r, or greater. Therefore we check 
+  // if r needs to be measured. If so, we simply measure it. If not, we 
+  // propagate the effect of measuring q all the way to the right. 
+  // In both cases, we propagate the effect all the way to the left.
   reg_t qubits_to_update;
   uint_t size = qubits.size();
   reg_t outcome_vector(size);

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -1500,7 +1500,8 @@ reg_t MPS::apply_measure_internal(const reg_t &qubits,
   bool measure_right_neighbor = false;
   // here we check if the next qubit to be measured is r (r's index is i+1)
   for (uint_t i=0; i<size; i++) {
-    measure_right_neighbor = (i<size-1 && sorted_qubits[i+1] == i+1);
+    measure_right_neighbor = (i<size-1 && 
+			      sorted_qubits[i+1] == sorted_qubits[i]+1);
 
     // The following line is correct because the qubits were sorted in apply_measure.
     // If the sort is cancelled, for the case of measure_all, we must measure

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -1490,7 +1490,7 @@ reg_t MPS::apply_measure_internal(const reg_t &qubits,
   // the next measured qubit will always be r, or greater. Therefore we check 
   // if r needs to be measured. If so, we simply measure it. If not, we 
   // propagate the effect of measuring q all the way to the right, until 
-  // We reach a qubit that should be measured. Then we measure that qubit
+  // we reach a qubit that should be measured. Then we measure that qubit
   // and continue the propagation to the right.
   // In both cases, we propagate the effect all the way to the left, because 
   // no more qubits will be measured on the left

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -890,7 +890,7 @@ void MPS::apply_kraus_internal(const reg_t &qubits,
     min_qubit = std::min(min_qubit, qubits[i]);
     max_qubit = std::max(max_qubit, qubits[i]);
   }
-  propagate_to_neighbors_internal(min_qubit, max_qubit);
+  propagate_to_neighbors_internal(min_qubit, max_qubit, num_qubits_-1);
 }
 
 void MPS::centralize_qubits(const reg_t &qubits, 
@@ -1489,30 +1489,35 @@ reg_t MPS::apply_measure_internal(const reg_t &qubits,
   // We sort 'qubits' at the beginning of the algorithm, so that the index of 
   // the next measured qubit will always be r, or greater. Therefore we check 
   // if r needs to be measured. If so, we simply measure it. If not, we 
-  // propagate the effect of measuring q all the way to the right. 
-  // In both cases, we propagate the effect all the way to the left.
+  // propagate the effect of measuring q all the way to the right, until 
+  // We reach a qubit that should be measured. Then we measure that qubit
+  // and continue the propagation to the right.
+  // In both cases, we propagate the effect all the way to the left, because 
+  // no more qubits will be measured on the left
   reg_t qubits_to_update;
   uint_t size = qubits.size();
   reg_t outcome_vector(size);
   reg_t sorted_qubits = qubits;
   std::sort(sorted_qubits.begin(), sorted_qubits.end());
 
-  bool measure_right_neighbor = false;
-  // here we check if the next qubit to be measured is r (r's index is i+1)
+  uint_t next_measured_qubit = num_qubits_-1;
   for (uint_t i=0; i<size; i++) {
-    measure_right_neighbor = (i<size-1 && 
-			      sorted_qubits[i+1] == sorted_qubits[i]+1);
+    if (i < size-1) {
+      next_measured_qubit = sorted_qubits[i+1];
+    } else {
+      next_measured_qubit = num_qubits_-1;
+    }
 
     // The following line is correct because the qubits were sorted in apply_measure.
     // If the sort is cancelled, for the case of measure_all, we must measure
     // in the order in which the qubits are organized
-    outcome_vector[i] = apply_measure_internal_single_qubit(sorted_qubits[i], rng, measure_right_neighbor);
+    outcome_vector[i] = apply_measure_internal_single_qubit(sorted_qubits[i], rng, next_measured_qubit);
   }
   return outcome_vector;
 }
 
 uint_t MPS::apply_measure_internal_single_qubit(uint_t qubit, RngEngine &rng, 
-						bool measure_right_neighbor) {	
+						uint_t next_measured_qubit) {	
   reg_t qubits_to_update;
   qubits_to_update.push_back(qubit);
 
@@ -1537,22 +1542,15 @@ uint_t MPS::apply_measure_internal_single_qubit(uint_t qubit, RngEngine &rng,
   }
   apply_matrix_internal(qubits_to_update, measurement_matrix);
   if (num_qubits_ > 1)
-    propagate_to_neighbors_internal(qubit, qubit, measure_right_neighbor);
+    propagate_to_neighbors_internal(qubit, qubit, next_measured_qubit);
 
   return measurement;
 }
 
 void MPS::propagate_to_neighbors_internal(uint_t min_qubit, uint_t max_qubit,
-					  bool measure_right_neighbor) {
-  uint_t right_qubit=num_qubits_-1;
-  int_t left_qubit=0;
-
-  if (measure_right_neighbor) {
-    right_qubit = (max_qubit >= num_qubits_-2) ? num_qubits_-1 : max_qubit + 1;
-  }
-
+					  uint_t next_measured_qubit) {
   // step 4 - propagate the changes to all qubits to the right
-  for (uint_t i=max_qubit; i<right_qubit; i++) {
+  for (uint_t i=max_qubit; i<next_measured_qubit; i++) {
     if (lambda_reg_[i].size() == 1) 
       break;   // no need to propagate if no entanglement
     apply_2_qubit_gate(i, i+1, id, cmatrix_t(1, 1));
@@ -1710,6 +1708,7 @@ void MPS::initialize_component_internal(const reg_t &qubits,
 }
 
 void MPS::reset(const reg_t &qubits, RngEngine &rng) {
+  move_all_qubits_to_sorted_ordering();
   reg_t internal_qubits = get_internal_qubits(qubits);
   reset_internal(internal_qubits, rng);
 }

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.cpp
@@ -1472,14 +1472,13 @@ reg_t MPS::sample_measure_using_probabilities_internal(const rvector_t &rnds,
     return samples;
 }
 
-reg_t MPS::apply_measure(const reg_t &qubits, RngEngine &rng) {
-  // since input is always sorted in qasm_controller, therefore, we must return the qubits 
-  // to their original location (sorted)
-  move_all_qubits_to_sorted_ordering();
-  return apply_measure_internal(qubits, rng);
+reg_t MPS::apply_measure(const reg_t &sorted_qubits, RngEngine &rng) {
+  // qubits in MPS structure have been moved to their original location
+  // input 'sorted_qubits' have been sorted
+  return apply_measure_internal(sorted_qubits, rng);
 }
 
-reg_t MPS::apply_measure_internal(const reg_t &qubits, 
+reg_t MPS::apply_measure_internal(const reg_t &sorted_qubits, 
 				  RngEngine &rng) {
   // For every qubit, q,  that is measured, we must propagate the effect of its
   // measurement to its neigbors, l and r, and then to their neighbors, and 
@@ -1495,10 +1494,8 @@ reg_t MPS::apply_measure_internal(const reg_t &qubits,
   // In both cases, we propagate the effect all the way to the left, because 
   // no more qubits will be measured on the left
   reg_t qubits_to_update;
-  uint_t size = qubits.size();
+  uint_t size = sorted_qubits.size();
   reg_t outcome_vector(size);
-  reg_t sorted_qubits = qubits;
-  std::sort(sorted_qubits.begin(), sorted_qubits.end());
 
   uint_t next_measured_qubit = num_qubits_-1;
   for (uint_t i=0; i<size; i++) {
@@ -1567,7 +1564,15 @@ void MPS::apply_initialize(const reg_t &qubits,
 			   const cvector_t &statevector,
 			   RngEngine &rng) {
   uint_t num_qubits = qubits.size();
+  // This is required because apply_measure assumes the qubits are sorted
+  move_all_qubits_to_sorted_ordering();
+  reg_t sorted_qubits = qubits;
+  std::sort(sorted_qubits.begin(), sorted_qubits.end());
   reg_t internal_qubits = get_internal_qubits(qubits);
+  std::cout << "internal_qubits = ";
+  for (uint_t i=0; i<internal_qubits.size(); i++)
+    std::cout << internal_qubits[i] << " ";
+std::cout << std::endl;
 
   uint_t num_amplitudes = statevector.size();
   cvector_t reordered_statevector(num_amplitudes);
@@ -1709,7 +1714,10 @@ void MPS::initialize_component_internal(const reg_t &qubits,
 
 void MPS::reset(const reg_t &qubits, RngEngine &rng) {
   move_all_qubits_to_sorted_ordering();
-  reg_t internal_qubits = get_internal_qubits(qubits);
+  reg_t sorted_qubits = qubits;
+  std::sort(sorted_qubits.begin(), sorted_qubits.end());
+  reg_t internal_qubits = get_internal_qubits(sorted_qubits);
+
   reset_internal(internal_qubits, rng);
 }
 

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -303,7 +303,7 @@ public:
   reg_t sample_measure_using_probabilities(const rvector_t &rnds, 
 					   const reg_t &qubits);
 
-  reg_t apply_measure(const reg_t &sorted_qubits, RngEngine &rng);
+  reg_t apply_measure(const reg_t &qubits, RngEngine &rng, bool is_sorted=false);
 
   //----------------------------------------------------------------
   // Function name: initialize_from_statevector_internal
@@ -414,7 +414,8 @@ private:
   void get_probabilities_vector_internal(rvector_t& probvector, const reg_t &qubits) const;
 
   reg_t apply_measure_internal(const reg_t &sorted_qubits,
-			       RngEngine &rng);
+			       RngEngine &rng,
+			       bool is_sorted=false);
 
   uint_t apply_measure_internal_single_qubit(uint_t qubit, RngEngine &rng, 
 					     uint_t next_measured_qubit);

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -357,7 +357,7 @@ private:
   // Certain local operations need to be propagated to the neighboring qubits. 
   // Such operations include apply_measure and apply_kraus
   void propagate_to_neighbors_internal(uint_t min_qubit, uint_t max_qubit, 
-				       bool measure_right_neighbor=false);
+				       uint_t next_measured_qubit);
 
   // apply_matrix for more than 2 qubits
   void apply_multi_qubit_gate(const reg_t &qubits,
@@ -414,7 +414,7 @@ private:
 			       RngEngine &rng);
 
   uint_t apply_measure_internal_single_qubit(uint_t qubit, RngEngine &rng, 
-					     bool measure_right_neighbor=false);
+					     uint_t next_measured_qubit);
 
   reg_t sample_measure_using_probabilities_internal(const rvector_t &rnds, 
 						    const reg_t &qubits) const;

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -119,7 +119,10 @@ public:
     else
       return "";
   }
-  
+
+  //----------------------------------------------------------------
+  void move_all_qubits_to_sorted_ordering();
+
 
   /////////////////////////////////////////////////////////////////
   // API functions
@@ -300,7 +303,7 @@ public:
   reg_t sample_measure_using_probabilities(const rvector_t &rnds, 
 					   const reg_t &qubits);
 
-  reg_t apply_measure(const reg_t &qubits, RngEngine &rng);
+  reg_t apply_measure(const reg_t &sorted_qubits, RngEngine &rng);
 
   //----------------------------------------------------------------
   // Function name: initialize_from_statevector_internal
@@ -410,7 +413,7 @@ private:
 
   void get_probabilities_vector_internal(rvector_t& probvector, const reg_t &qubits) const;
 
-  reg_t apply_measure_internal(const reg_t &qubits,
+  reg_t apply_measure_internal(const reg_t &sorted_qubits,
 			       RngEngine &rng);
 
   uint_t apply_measure_internal_single_qubit(uint_t qubit, RngEngine &rng, 
@@ -464,10 +467,6 @@ private:
   //----------------------------------------------------------------
   void move_qubits_to_centralized_indices(const reg_t &sorted_indices,
 					  const reg_t &centralized_qubits);
-
-  //----------------------------------------------------------------
-  void move_all_qubits_to_sorted_ordering();
-
 
   // Function name: change_position
   // Description: Move qubit from src to dst in the MPS. Used only

--- a/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
+++ b/src/simulators/matrix_product_state/matrix_product_state_internal.hpp
@@ -357,7 +357,7 @@ private:
   // Certain local operations need to be propagated to the neighboring qubits. 
   // Such operations include apply_measure and apply_kraus
   void propagate_to_neighbors_internal(uint_t min_qubit, uint_t max_qubit, 
-				       bool measure_all=false);
+				       bool measure_right_neighbor=false);
 
   // apply_matrix for more than 2 qubits
   void apply_multi_qubit_gate(const reg_t &qubits,
@@ -414,7 +414,7 @@ private:
 			       RngEngine &rng);
 
   uint_t apply_measure_internal_single_qubit(uint_t qubit, RngEngine &rng, 
-					     bool measure_all=false);
+					     bool measure_right_neighbor=false);
 
   reg_t sample_measure_using_probabilities_internal(const rvector_t &rnds, 
 						    const reg_t &qubits) const;

--- a/test/terra/backends/test_qasm_simulator_matrix_product_state.py
+++ b/test/terra/backends/test_qasm_simulator_matrix_product_state.py
@@ -51,7 +51,6 @@ from test.terra.backends.qasm_simulator.qasm_set_state import QasmSetStateTests
 # Snapshot tests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStatevectorTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotDensityMatrixTests
-from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotStabilizerTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotProbabilitiesTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliTests
 from test.terra.backends.qasm_simulator.qasm_snapshot import QasmSnapshotExpValPauliNCTests
@@ -83,7 +82,6 @@ class TestQasmMatrixProductStateSimulator(
         QasmSnapshotStatevectorTests,
         QasmSnapshotDensityMatrixTests,
         QasmSnapshotProbabilitiesTests,
-        QasmSnapshotStabilizerTests,
         QasmSnapshotExpValPauliTests,
         QasmSnapshotExpValPauliNCTests,
         QasmSnapshotExpValMatrixTests,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added a call to `move_all_qubits_to_sorted_ordering` in `sample_measure_using_apply_measure` so that it is only called once for all shots and not once for every shot.


### Details and comments
I added a flag `is_sorted` to the interface of `apply_measure` and `apply_measure_internal` to indicated whether they qubits were already sorted outside these functions. The reason is that the methods `apply_reset` and `apply_initialize` do not agree with sorting the qubits in advance.

